### PR TITLE
feat: add threshold (black & white) filter with -t flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,22 @@ The vignette filter gives an image a cinematic look by gradually darkening its c
 
 If you apply this algorithm, your resulting image will have gently darkened corners and an undisturbed/sunnier center.
 
+### 6.) The Threshold Algorithm
+
+The “threshold” filter converts a colorful image into a pure black-and-white one based on pixel intensity.
+
+For each pixel, the intensity is calculated as the average of its red, green, and blue values:
+
+\[
+\text{intensity} = \frac{(R + G + B)}{3}
+\]
+
+If the intensity is **greater than or equal to 128**, the pixel is set to **white** (`R = G = B = 255`).
+Otherwise, it is set to **black** (`R = G = B = 0`).
+
+This results in a high-contrast, two-tone image where all intermediate shades are eliminated — essentially a hard binary “black-and-white” conversion.
+
+
 ---
 
 ### Usage

--- a/filter.c
+++ b/filter.c
@@ -7,7 +7,7 @@
 int main(int argc, char *argv[])
 {
     // Define allowable filters
-    char *filters = "bgrsiv";
+    char *filters = "bgrsivt";
 
     
     char filterArr[argc-3];
@@ -127,6 +127,9 @@ int main(int argc, char *argv[])
         // Vignette
         case 'v':
             vignette(height, width, image);
+            break;
+        case 't':
+            threshold(height, width, image);
             break;
         default:
             printf("%c", &filterArr[i]);

--- a/helpers.c
+++ b/helpers.c
@@ -171,3 +171,30 @@ void vignette(int height, int width, RGBTRIPLE image[height][width]){
         }
     }
 }
+
+//Threshold Filter(Black & White)
+void threshold(int height, int width, RGBTRIPLE image[height][width])
+{
+    for (int i = 0; i < height; i++)
+    {
+        for (int j = 0; j < width; j++)
+        {
+            int avg = round((image[i][j].rgbtRed +
+                             image[i][j].rgbtGreen +
+                             image[i][j].rgbtBlue) / 3.0);
+
+            if (avg >= 128)
+            {
+                image[i][j].rgbtRed = 255;
+                image[i][j].rgbtGreen = 255;
+                image[i][j].rgbtBlue = 255;
+            }
+            else
+            {
+                image[i][j].rgbtRed = 0;
+                image[i][j].rgbtGreen = 0;
+                image[i][j].rgbtBlue = 0;
+            }
+        }
+    }
+}

--- a/helpers.h
+++ b/helpers.h
@@ -16,3 +16,6 @@ void reflect(int height, int width, RGBTRIPLE image[height][width]);
 void blur(int height, int width, RGBTRIPLE image[height][width]);
 // Vignette image
 void vignette(int height, int width, RGBTRIPLE image[height][width]);
+
+//Threshold Filter(Black & White)
+void threshold(int height, int width, RGBTRIPLE image[height][width]);


### PR DESCRIPTION
## Description

> Implemented a new **Threshold Filter (-t flag)** that converts each pixel of an image to pure black or white based on average intensity.  
>
> The filter was added to `helpers.c`, declared in `helpers.h`, registered in `filter.c`, and documented in `README.md`.  
>
> **Usage:**
> ```bash
> ./filter -t input.bmp output.bmp
> ```
> This applies the black-and-white threshold effect.

---

## Semver Changes

- [ ] Patch (bug fix, no new features)
- [x] Minor (new features, no breaking changes)
- [ ] Major (breaking changes)

---

## Issues

> Closes #18 — *Feature: Threshold Filter (Black & White)*

---

## Checklist

- [x] I have read the [Contributing Guidelines](../Contributor_Guide/Contruting.md).  
- [x] Code compiles successfully without modifying existing logic.  
- [x] Feature tested locally using sample `.bmp` files.  
- [x] README updated with new filter usage.  
